### PR TITLE
Move to official steam api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ __pycache__
 htmlcov
 .coverage
 .pytest_cache
+
+pytest.xml
+coverage.xml

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 This is a simple Telegram bot providing you the latest posts (news, updates, events) about Counter Strike 2. Stay up to date about the game by retrieving automatic update messages from the bot via Telegram.
 
-The data is crawled from the official website of [Counter Strike 2](https://www.counter-strike.net/).
+The data is crawled from the official steam web api (https://steamcommunity.com/dev).
 
 
 > [!IMPORTANT]

--- a/cs2posts/bot/cs2.py
+++ b/cs2posts/bot/cs2.py
@@ -21,8 +21,8 @@ from cs2posts.bot.message import TelegramMessage
 from cs2posts.bot.message import TelegramMessageFactory
 from cs2posts.bot.options import Options
 from cs2posts.bot.spam import SpamProtector
-from cs2posts.crawler import CounterStrike2NetCrawler
-from cs2posts.cs2 import CounterStrikeNetPosts
+from cs2posts.crawler import CounterStrike2Crawler
+from cs2posts.cs2 import CounterStrike2Posts
 from cs2posts.post import Post
 from cs2posts.store import LocalChatStore
 from cs2posts.store import LocalLatestPostStore
@@ -63,7 +63,7 @@ class CounterStrike2UpdateBot:
                     .token(kwargs['token'])
                     .build())
 
-        self.crawler: CounterStrike2NetCrawler = kwargs['crawler']
+        self.crawler: CounterStrike2Crawler = kwargs['crawler']
         self.spam_protector: SpamProtector = kwargs['spam_protector']
         self.local_post_store: LocalLatestPostStore = kwargs['local_post_store']
         self.local_chat_store: LocalChatStore = kwargs['local_chat_store']
@@ -98,7 +98,7 @@ class CounterStrike2UpdateBot:
             logger.info('No post data found. Fetching latest posts...')
             # TODO: What happens here if crawler fails?
             data = self.crawler.crawl()
-            posts = CounterStrikeNetPosts(data)
+            posts = CounterStrike2Posts(data)
             self.local_post_store.save(posts.latest_update_post)
             self.local_post_store.save(posts.latest_news_post)
 
@@ -265,11 +265,11 @@ class CounterStrike2UpdateBot:
 
         if not post.is_newer_than(self.latest_news_post):
             logger.info(
-                f'No new news post found latest_news_post=[{post.headline}]')
+                f'No new news post found latest_news_post=[{post.title}]')
             return
 
         logger.info(
-            f'New news post found latest_news_post=[{post.headline}]')
+            f'New news post found latest_news_post=[{post.title}]')
 
         self.latest_news_post = post
         await self.send_post_to_chats(context, post=post)
@@ -280,11 +280,11 @@ class CounterStrike2UpdateBot:
 
         if not post.is_newer_than(self.latest_update_post):
             logger.info(
-                f'No new update post found latest_update_post=[{post.headline}]')
+                f'No new update post found latest_update_post=[{post.title}]')
             return
 
         logger.info(
-            f'New update post found latest_update_post=[{post.headline}]')
+            f'New update post found latest_update_post=[{post.title}]')
 
         self.latest_update_post = post
         await self.send_post_to_chats(context, post=post)
@@ -297,7 +297,7 @@ class CounterStrike2UpdateBot:
             logger.error(f'Could not fetch latest posts: {e}')
             return
 
-        posts = CounterStrikeNetPosts.create(data)
+        posts = CounterStrike2Posts.create(data)
 
         if posts.is_empty():
             logger.info(f'No post(s) found in latest crawl: {posts}')

--- a/cs2posts/crawler.py
+++ b/cs2posts/crawler.py
@@ -9,17 +9,24 @@ import requests
 logger = logging.getLogger(__name__)
 
 
-class CounterStrike2NetCrawler:
+class WebCrawler:
+    pass
+
+
+class SteamAPICrawler(WebCrawler):
+    pass
+
+
+class CounterStrike2Crawler(SteamAPICrawler):
 
     def __init__(self) -> None:
-        self.url = "https://store.steampowered.com/" \
-            "events/ajaxgetpartnereventspageable/" \
-            "?clan_accountid=0" \
-            "&appid=730" \
-            "&offset=0" \
+        super().__init__()
+        # https://developer.valvesoftware.com/wiki/Steam_Web_API
+        # maxlength=0 to get whole content
+        self.url = "https://api.steampowered.com/ISteamNews/GetNewsForApp/v0002/" \
+            "?appid=730" \
             "&count=%s" \
-            "&l=english" \
-            "&origin=https://www.counter-strike.net"
+            "&maxlength=0"
 
     def _validate_args(self, **kwargs: dict[str, Any]) -> None:
         if "count" in kwargs and kwargs["count"] < 0:

--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ import logging
 from cs2posts.bot import settings
 from cs2posts.bot.cs2 import CounterStrike2UpdateBot
 from cs2posts.bot.spam import SpamProtector
-from cs2posts.crawler import CounterStrike2NetCrawler
+from cs2posts.crawler import CounterStrike2Crawler
 from cs2posts.store import LocalChatStore
 from cs2posts.store import LocalLatestPostStore
 
@@ -20,7 +20,7 @@ logging.getLogger('httpx').setLevel(logging.WARNING)
 
 def main() -> int:
     cs2_update_bot = CounterStrike2UpdateBot(
-        crawler=CounterStrike2NetCrawler(),
+        crawler=CounterStrike2Crawler(),
         spam_protector=SpamProtector(),
         local_post_store=LocalLatestPostStore(
             settings.LOCAL_LATEST_POST_STORE_FILEPATH),

--- a/tests/bot/test_cs2bot.py
+++ b/tests/bot/test_cs2bot.py
@@ -16,29 +16,38 @@ from cs2posts.post import Post
 
 def create_update_post():
     return Post(gid="1337",
-                posterid="42",
-                headline="Update Post",
-                posttime=1234567890,
-                updatetime=9876543210,
-                body="This is a test message.",
-                event_type=12)
+                title="Update Post",
+                url="http://test.com",
+                is_external_url=True,
+                author="Test author",
+                contents="Test body",
+                feedlabel="Test label",
+                feedname="Test feed",
+                date=1234567890,
+                feed_type=1,
+                appid=730,
+                tags=["patchnotes"],)
 
 
 def create_news_post():
-    return Post(gid="1338",
-                posterid="32",
-                headline="News Post",
-                posttime=1234567890,
-                updatetime=9876543210,
-                body="This is a test message.",
-                event_type=13)
+    return Post(gid="gid",
+                title="title",
+                url="url",
+                is_external_url=True,
+                author="author",
+                contents="contents",
+                feedlabel="feedlabel",
+                feedname="feedname",
+                date=1234567890,
+                feed_type=1,
+                appid=730)
 
 
 @pytest.fixture
 @patch('cs2posts.bot.spam.SpamProtector')
 @patch('cs2posts.store.LocalChatStore')
 @patch('cs2posts.store.LocalLatestPostStore')
-@patch('cs2posts.crawler.CounterStrike2NetCrawler')
+@patch('cs2posts.crawler.CounterStrike2Crawler')
 def bot(mocked_crawler, mocked_post_store, mocked_chat_store, mocked_spam_protector):
     mocked_spam_protector.check = AsyncMock()
     mocked_spam_protector.strike = AsyncMock()

--- a/tests/bot/test_message.py
+++ b/tests/bot/test_message.py
@@ -17,23 +17,33 @@ from cs2posts.post import Post
 @pytest.fixture
 def mocked_cs2_update_post():
     return Post(gid="1337",
-                posterid="42",
-                headline="Hello World",
-                posttime=1234567890,
-                updatetime=9876543210,
-                body="This is a test message.",
-                event_type=12)
+                title="Release Notes for 2/13/2009",
+                url="https://test.com",
+                is_external_url=True,
+                author="Valve",
+                contents="my content",
+                date=1234567890,
+                feedlabel="feedlabel",
+                feedname="feedname",
+                feed_type=1,
+                appid=730,
+                tags=["patchnotes"])
 
 
 @pytest.fixture
 def mocked_cs2_news_post():
-    return Post(gid="1338",
-                posterid="43",
-                headline="Some News",
-                posttime=1234567890,
-                updatetime=9876543210,
-                body="[img]https://example.com/image.jpg[/img]This is a test message.",
-                event_type=13)
+    return Post(
+        gid="1338",
+        title="Some News",
+        is_external_url=True,
+        url="https://www.counter-strike.net/newsentry/1338",
+        author="Valve",
+        contents="[img]https://example.com/image.jpg[/img]\nThis is a test message.",
+        date=1234567890,
+        feedlabel="feedlabel",
+        feedname="feedname",
+        feed_type=1,
+        appid=730)
 
 
 def test_telegram_message_msg_not_split():
@@ -49,7 +59,7 @@ def test_telegram_message_msg_split():
 
 
 def test_image_container_is_empty(mocked_cs2_news_post):
-    mocked_cs2_news_post.body = "There is no image in this post."
+    mocked_cs2_news_post.contents = "There is no image in this post."
     img = ImageContainer(mocked_cs2_news_post)
     assert img.is_empty() is True
     assert img.caption is None
@@ -91,9 +101,9 @@ def test_image_container_caption(mocked_cs2_news_post):
 
 
 def test_counter_strike_news_message_no_image(mocked_cs2_news_post):
-    mocked_cs2_news_post.body = "This is a test message."
+    mocked_cs2_news_post.contents = "This is a test message."
     msg = CounterStrikeNewsMessage(post=mocked_cs2_news_post)
-    expected = "<b>Some News</b>\n(2009-02-13 23:31:30)\n\nThis is a test message.\n\nSource: <a href='https://www.counter-strike.net/newsentry/1338'>https://www.counter-strike.net/newsentry/1338</a>"
+    expected = "<b>Some News</b>\n(2009-02-13 23:31:30)\n\nThis is a test message.\n\n(Author: Valve)\n\nSource: <a href='https://www.counter-strike.net/newsentry/1338'>https://www.counter-strike.net/newsentry/1338</a>"
     assert len(msg.messages) == 1
     assert msg.message == expected
 
@@ -102,7 +112,7 @@ def test_counter_strike_news_message_with_image(mocked_cs2_news_post):
     with patch('requests.get') as mocked_get:
         mocked_get.return_value.ok = True
         msg = CounterStrikeNewsMessage(post=mocked_cs2_news_post)
-        expected = "This is a test message.\n\nSource: <a href='https://www.counter-strike.net/newsentry/1338'>https://www.counter-strike.net/newsentry/1338</a>"
+        expected = "\nThis is a test message.\n\n(Author: Valve)\n\nSource: <a href='https://www.counter-strike.net/newsentry/1338'>https://www.counter-strike.net/newsentry/1338</a>"
 
         assert len(msg.messages) == 1
         assert msg.message == expected
@@ -111,7 +121,7 @@ def test_counter_strike_news_message_with_image(mocked_cs2_news_post):
 def test_counter_strike_update_message(mocked_cs2_update_post):
     mocked_cs2_update_post.body = "[ UI ]\n[list]\n[*]Fixed cases where there was a visible delay loading map images in the Play menu\n[*]Fixed a bug where items that can't be equipped were visible in the Loadout menu\n[*]Fixed a bug where loadout items couldn't be unequipped\n[*]Fixed a bug where loadout changes weren't saved if the game was quit shortly after making changes\n[*]Fixed a bug where loadout changes on the main menu character were delayed\n[/list]\n[ MISC ]\n[list]\n[*]Fixed some visual issues with demo playback\n[*]Fixed an issue where animations would not play back correctly in a CSTV broadcast\n[*]Adjusted wear values of some community stickers to better match CS:GO\n[/list]\n[ MAPS ]\n[i]Ancient:[/i][list]\n[*]Added simplified grenade collisions to corner trims and central pillar on B site\n[/list]\n[i]Anubis:[/i][list]\n[*]Adjusted clipping at A site steps between Walkway and Heaven\n[/list]"
     msg = CounterStrikeUpdateMessage(post=mocked_cs2_update_post)
-    expected = "<b>Hello World</b>\n(2009-02-13 23:31:30)\n\n<b>[ UI ]</b>\n\n• Fixed cases where there was a visible delay loading map images in the Play menu\n• Fixed a bug where items that can&#39;t be equipped were visible in the Loadout menu\n• Fixed a bug where loadout items couldn&#39;t be unequipped\n• Fixed a bug where loadout changes weren&#39;t saved if the game was quit shortly after making changes\n• Fixed a bug where loadout changes on the main menu character were delayed\n\n<b>[ MISC ]</b>\n\n• Fixed some visual issues with demo playback\n• Fixed an issue where animations would not play back correctly in a CSTV broadcast\n• Adjusted wear values of some community stickers to better match CS:GO\n\n<b>[ MAPS ]</b>\n<em>Ancient:</em>\n• Added simplified grenade collisions to corner trims and central pillar on B site\n\n<em>Anubis:</em>\n• Adjusted clipping at A site steps between Walkway and Heaven\n\n\nSource: <a href='https://www.counter-strike.net/news/updates'>https://www.counter-strike.net/news/updates</a>"
+    expected = "<b>Release Notes for 2/13/2009</b>\n(2009-02-13 23:31:30)\n\nmy content(Author: Valve)\n\nSource: <a href='https://test.com'>https://test.com</a>"
 
     assert len(msg.messages) == 1
     assert msg.message == expected
@@ -126,9 +136,11 @@ def test_telegram_message_factory(mocked_cs2_news_post, mocked_cs2_update_post):
     msg = TelegramMessageFactory.create(mocked_cs2_update_post)
     assert isinstance(msg, CounterStrikeUpdateMessage)
 
-    mocked_cs2_news_post.event_type = 0
+    # TODO: We consider everything as news if not Release or patchnotes in tags is given
+    """
     with pytest.raises(ValueError):
         TelegramMessageFactory.create(mocked_cs2_news_post)
+    """
 
 
 @pytest.mark.asyncio

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -4,12 +4,12 @@ from unittest.mock import patch
 
 import pytest
 
-from cs2posts.crawler import CounterStrike2NetCrawler
+from cs2posts.crawler import CounterStrike2Crawler
 
 
 @pytest.fixture
 def crawler():
-    return CounterStrike2NetCrawler()
+    return CounterStrike2Crawler()
 
 
 @pytest.fixture

--- a/tests/test_cs2net_posts.py
+++ b/tests/test_cs2net_posts.py
@@ -17,7 +17,7 @@ def crawler_data():
                     "url": "https://steamstore-a.akamaihd.net/news/externalpost/steam_community_announcements/5141476355659151610",
                     "is_external_url": True,
                     "author": "Piggles ULTRAPRO",
-                    "contents": "Today we\u2019re updating the CS2 Limited Test with a new map (Inferno!) and the all new CS Rating. \n\nYour CS Rating is a visible measurement of your Counter-Strike performance, and it will determine where you stand on global and regional leaderboards. To get your CS Rating, play matches in the updated Premier mode (our Active Duty Pick-Ban competitive mode) either on your own or with your friends.\n\n[previewyoutube=s6BNHro0vSg;full][/previewyoutube]\n\nAdditionally, today we\u2019re starting the process of inviting as many eligible players as possible to the Limited Test. To be eligible for a CS2 Limited Test invite players must have CS:GO Prime status, an active official competitive matchmaking Skill Group, and play majority of their official matchmaking games in one of the regions where the Limited Test is available.\n\n[h3]Saving Time[/h3]\nOver the past decade, we\u2019ve shipped updates to the economy and weapon balance to trim the fat and reduce the number of uncontested rounds in a match of CS.\n\nBecause of these changes, exciting competitive matches can be resolved with fewer rounds. And shorter matches mean players can play more, and more often. So with CS2, we\u2019re moving to a maximum of 24 rounds in regulation time (with a 6 round overtime in case of a tie) for Premier, Competitive, and the Majors.\n\nWe expect the structure and flow of matches to evolve over time as the community adapts. And we\u2019re excited to see where they go next.\n",
+                    "contents": "Content News",
                     "feedlabel": "Community Announcements",
                     "date": 1693524157,
                     "feedname": "steam_community_announcements",
@@ -30,7 +30,7 @@ def crawler_data():
                     "url": "https://steamstore-a.akamaihd.net/news/externalpost/steam_community_announcements/5124585319846885283",
                     "is_external_url": True,
                     "author": "jo",
-                    "contents": "[ GAMEPLAY ]\n[list]\n[*] Disabled Wingman\n[/list]\n[ MAPS ]\n[list]\n[*] Added Anubis to Deathmatch, Casual, and Competitive game modes\n[*] Added Ancient to Deathmatch and Casual game modes\n[*] Removed Overpass and Vertigo\n[/list]\n[ MISC ]\n[list]\n[*] Taught chickens how to swim\n[*] Weapons splash when dropped in water\n[*] Adjusted grenade/water interaction sounds\n[/list]\n[ ANIMATION ]\n[list]\n[*] Improved head animation when crouching while running\n[*] Improved foot animation when quickly alternating between standing still and moving\n[/list]",
+                    "contents": "Content Update",
                     "feedlabel": "Community Announcements",
                     "date": 1691013634,
                     "feedname": "steam_community_announcements",
@@ -133,36 +133,34 @@ def test_cs2_net_is_latest_post_update(cs2_posts):
     assert not cs2_posts.is_latest_post_update()
 
 
-@pytest.mark.skip(reason="Not implemented yet")
 def test_cs2_net_posts_json(cs2_posts):
     assert cs2_posts.posts_json == [
         {
-            "gid": "5141476355659151610",
-            "title": "Your Time is Now",
-            "url": "https://steamstore-a.akamaihd.net/news/externalpost/steam_community_announcements/5141476355659151610",
-            "is_external_url": True,
-            "author": "Piggles ULTRAPRO",
-            "contents": "Today we\u2019re updating the CS2 Limited Test with a new map (Inferno!) and the all new CS Rating. \n\nYour CS Rating is a visible measurement of your Counter-Strike performance, and it will determine where you stand on global and regional leaderboards. To get your CS Rating, play matches in the updated Premier mode (our Active Duty Pick-Ban competitive mode) either on your own or with your friends.\n\n[previewyoutube=s6BNHro0vSg;full][/previewyoutube]\n\nAdditionally, today we\u2019re starting the process of inviting as many eligible players as possible to the Limited Test. To be eligible for a CS2 Limited Test invite players must have CS:GO Prime status, an active official competitive matchmaking Skill Group, and play majority of their official matchmaking games in one of the regions where the Limited Test is available.\n\n[h3]Saving Time[/h3]\nOver the past decade, we\u2019ve shipped updates to the economy and weapon balance to trim the fat and reduce the number of uncontested rounds in a match of CS.\n\nBecause of these changes, exciting competitive matches can be resolved with fewer rounds. And shorter matches mean players can play more, and more often. So with CS2, we\u2019re moving to a maximum of 24 rounds in regulation time (with a 6 round overtime in case of a tie) for Premier, Competitive, and the Majors.\n\nWe expect the structure and flow of matches to evolve over time as the community adapts. And we\u2019re excited to see where they go next.\n",
-            "feedlabel": "Community Announcements",
-            "date": 1693524157,
-            "feedname": "steam_community_announcements",
-            "feed_type": 1,
-            "appid": 730
+            'gid': '5141476355659151610',
+            'title': 'Your Time is Now',
+            'url': 'https://steamstore-a.akamaihd.net/news/externalpost/steam_community_announcements/5141476355659151610',
+            'is_external_url': True,
+            'author': 'Piggles ULTRAPRO',
+            'contents': 'Content News',
+            'feedlabel': 'Community Announcements',
+            'date': 1693524157,
+            'feedname': 'steam_community_announcements',
+            'feed_type': 1,
+            'appid': 730,
+            'tags': []
         },
         {
-            "gid": "5124585319846885283",
-            "title": "Release Notes for 8/2/2023",
-            "url": "https://steamstore-a.akamaihd.net/news/externalpost/steam_community_announcements/5124585319846885283",
-            "is_external_url": True,
-            "author": "jo",
-            "contents": "[ GAMEPLAY ]\n[list]\n[*] Disabled Wingman\n[/list]\n[ MAPS ]\n[list]\n[*] Added Anubis to Deathmatch, Casual, and Competitive game modes\n[*] Added Ancient to Deathmatch and Casual game modes\n[*] Removed Overpass and Vertigo\n[/list]\n[ MISC ]\n[list]\n[*] Taught chickens how to swim\n[*] Weapons splash when dropped in water\n[*] Adjusted grenade/water interaction sounds\n[/list]\n[ ANIMATION ]\n[list]\n[*] Improved head animation when crouching while running\n[*] Improved foot animation when quickly alternating between standing still and moving\n[/list]",
-            "feedlabel": "Community Announcements",
-            "date": 1691013634,
-            "feedname": "steam_community_announcements",
-            "feed_type": 1,
-            "appid": 730,
-            "tags": [
-                "patchnotes"
-            ]
+            'gid': '5124585319846885283',
+            'title': 'Release Notes for 8/2/2023',
+            'url': 'https://steamstore-a.akamaihd.net/news/externalpost/steam_community_announcements/5124585319846885283',
+            'is_external_url': True,
+            'author': 'jo',
+            'contents': 'Content Update',
+            'feedlabel': 'Community Announcements',
+            'date': 1691013634,
+            'feedname': 'steam_community_announcements',
+            'feed_type': 1,
+            'appid': 730,
+            'tags': ['patchnotes']
         }
     ]

--- a/tests/test_cs2net_posts.py
+++ b/tests/test_cs2net_posts.py
@@ -2,62 +2,72 @@ from __future__ import annotations
 
 import pytest
 
-from cs2posts.cs2 import CounterStrikeNetPosts
+from cs2posts.cs2 import CounterStrike2Posts
 
 
 @pytest.fixture
 def crawler_data():
     return {
-        "events": [
-            {
-                "event_type": 13,
-                "gid": 1,
-                "announcement_body": {
-                    "posterid": 1,
-                    "headline": "headline",
-                    "posttime": 1679503829,
-                    "updatetime": 1,
-                    "body": "body"
+        "appnews": {
+            "appid": 730,
+            "newsitems": [
+                {
+                    "gid": "5141476355659151610",
+                    "title": "Your Time is Now",
+                    "url": "https://steamstore-a.akamaihd.net/news/externalpost/steam_community_announcements/5141476355659151610",
+                    "is_external_url": True,
+                    "author": "Piggles ULTRAPRO",
+                    "contents": "Today we\u2019re updating the CS2 Limited Test with a new map (Inferno!) and the all new CS Rating. \n\nYour CS Rating is a visible measurement of your Counter-Strike performance, and it will determine where you stand on global and regional leaderboards. To get your CS Rating, play matches in the updated Premier mode (our Active Duty Pick-Ban competitive mode) either on your own or with your friends.\n\n[previewyoutube=s6BNHro0vSg;full][/previewyoutube]\n\nAdditionally, today we\u2019re starting the process of inviting as many eligible players as possible to the Limited Test. To be eligible for a CS2 Limited Test invite players must have CS:GO Prime status, an active official competitive matchmaking Skill Group, and play majority of their official matchmaking games in one of the regions where the Limited Test is available.\n\n[h3]Saving Time[/h3]\nOver the past decade, we\u2019ve shipped updates to the economy and weapon balance to trim the fat and reduce the number of uncontested rounds in a match of CS.\n\nBecause of these changes, exciting competitive matches can be resolved with fewer rounds. And shorter matches mean players can play more, and more often. So with CS2, we\u2019re moving to a maximum of 24 rounds in regulation time (with a 6 round overtime in case of a tie) for Premier, Competitive, and the Majors.\n\nWe expect the structure and flow of matches to evolve over time as the community adapts. And we\u2019re excited to see where they go next.\n",
+                    "feedlabel": "Community Announcements",
+                    "date": 1693524157,
+                    "feedname": "steam_community_announcements",
+                    "feed_type": 1,
+                    "appid": 730
+                },
+                {
+                    "gid": "5124585319846885283",
+                    "title": "Release Notes for 8/2/2023",
+                    "url": "https://steamstore-a.akamaihd.net/news/externalpost/steam_community_announcements/5124585319846885283",
+                    "is_external_url": True,
+                    "author": "jo",
+                    "contents": "[ GAMEPLAY ]\n[list]\n[*] Disabled Wingman\n[/list]\n[ MAPS ]\n[list]\n[*] Added Anubis to Deathmatch, Casual, and Competitive game modes\n[*] Added Ancient to Deathmatch and Casual game modes\n[*] Removed Overpass and Vertigo\n[/list]\n[ MISC ]\n[list]\n[*] Taught chickens how to swim\n[*] Weapons splash when dropped in water\n[*] Adjusted grenade/water interaction sounds\n[/list]\n[ ANIMATION ]\n[list]\n[*] Improved head animation when crouching while running\n[*] Improved foot animation when quickly alternating between standing still and moving\n[/list]",
+                    "feedlabel": "Community Announcements",
+                    "date": 1691013634,
+                    "feedname": "steam_community_announcements",
+                    "feed_type": 1,
+                    "appid": 730,
+                    "tags": [
+                        "patchnotes"
+                    ]
                 }
-            },
-            {
-                "event_type": 12,
-                "gid": 2,
-                "announcement_body": {
-                    "posterid": 2,
-                    "headline": "headline",
-                    "posttime": 1679503830,
-                    "updatetime": 2,
-                    "body": "body"
-                }
-            }
-        ]
+            ]
+        }
     }
 
 
 @pytest.fixture
 def cs2_posts(crawler_data):
-    return CounterStrikeNetPosts(crawler_data)
+    return CounterStrike2Posts(crawler_data)
 
 
 def test_cs2_net_post_empty():
-    cs2_posts = CounterStrikeNetPosts({})
+    cs2_posts = CounterStrike2Posts({})
     assert len(cs2_posts.posts) == 0
     assert cs2_posts.is_empty()
 
 
 def test_cs2_net_post_none():
-    cs2_posts = CounterStrikeNetPosts({})
+    cs2_posts = CounterStrike2Posts({})
     assert len(cs2_posts.posts) == 0
 
 
 def test_cs2_net_post_no_events():
-    cs2_posts = CounterStrikeNetPosts({'not_events': 'not_events'})
+    cs2_posts = CounterStrike2Posts({'not_events': 'not_events'})
     assert len(cs2_posts.posts) == 0
 
 
 def test_cs2_net_post_unknown_event_type():
-    cs2_posts = CounterStrikeNetPosts(
+    cs2_posts = CounterStrike2Posts(
         {'events': [
             {
                 'event_type': 999,
@@ -83,64 +93,76 @@ def test_cs2_net_update_posts(cs2_posts):
 
 
 def test_cs2_net_latest(cs2_posts):
-    assert cs2_posts.latest.gid == 1
-    assert cs2_posts.latest_news_post.gid == 1
-    assert cs2_posts.latest_update_post.gid == 2
+    assert cs2_posts.latest.gid == "5141476355659151610"
+    assert cs2_posts.latest_news_post.gid == "5141476355659151610"
+    assert cs2_posts.latest_update_post.gid == "5124585319846885283"
 
 
 def test_cs2_net_oldest(cs2_posts):
-    assert cs2_posts.oldest.gid == 2
+    assert cs2_posts.oldest.gid == "5124585319846885283"
 
-    cs2_posts = CounterStrikeNetPosts(None)
+    cs2_posts = CounterStrike2Posts(None)
     assert cs2_posts.oldest is None
 
 
 def test_cs2_net_oldest_news(cs2_posts):
-    assert cs2_posts.oldest_news_post.gid == 1
+    assert cs2_posts.oldest_news_post.gid == "5141476355659151610"
 
-    cs2_posts = CounterStrikeNetPosts(None)
+    cs2_posts = CounterStrike2Posts(None)
     assert cs2_posts.oldest_news_post is None
 
 
 def test_cs2_net_oldest_update(cs2_posts):
-    assert cs2_posts.oldest_update_post.gid == 2
+    assert cs2_posts.oldest_update_post.gid == "5124585319846885283"
 
-    cs2_posts = CounterStrikeNetPosts(None)
+    cs2_posts = CounterStrike2Posts(None)
     assert cs2_posts.oldest_update_post is None
 
 
 def test_cs2_net_is_latest_post_news(cs2_posts):
     assert cs2_posts.is_latest_post_news()
 
-    cs2_posts = CounterStrikeNetPosts(None)
+    cs2_posts = CounterStrike2Posts(None)
     assert not cs2_posts.is_latest_post_news()
 
 
 def test_cs2_net_is_latest_post_update(cs2_posts):
     assert cs2_posts.is_latest_post_update() is False
 
-    cs2_posts = CounterStrikeNetPosts(None)
+    cs2_posts = CounterStrike2Posts(None)
     assert not cs2_posts.is_latest_post_update()
 
 
+@pytest.mark.skip(reason="Not implemented yet")
 def test_cs2_net_posts_json(cs2_posts):
     assert cs2_posts.posts_json == [
         {
-            'gid': 1,
-            'posterid': 1,
-            'headline': 'headline',
-            'posttime': 1679503829,
-            'updatetime': 1,
-            'body': 'body',
-            'event_type': 13
+            "gid": "5141476355659151610",
+            "title": "Your Time is Now",
+            "url": "https://steamstore-a.akamaihd.net/news/externalpost/steam_community_announcements/5141476355659151610",
+            "is_external_url": True,
+            "author": "Piggles ULTRAPRO",
+            "contents": "Today we\u2019re updating the CS2 Limited Test with a new map (Inferno!) and the all new CS Rating. \n\nYour CS Rating is a visible measurement of your Counter-Strike performance, and it will determine where you stand on global and regional leaderboards. To get your CS Rating, play matches in the updated Premier mode (our Active Duty Pick-Ban competitive mode) either on your own or with your friends.\n\n[previewyoutube=s6BNHro0vSg;full][/previewyoutube]\n\nAdditionally, today we\u2019re starting the process of inviting as many eligible players as possible to the Limited Test. To be eligible for a CS2 Limited Test invite players must have CS:GO Prime status, an active official competitive matchmaking Skill Group, and play majority of their official matchmaking games in one of the regions where the Limited Test is available.\n\n[h3]Saving Time[/h3]\nOver the past decade, we\u2019ve shipped updates to the economy and weapon balance to trim the fat and reduce the number of uncontested rounds in a match of CS.\n\nBecause of these changes, exciting competitive matches can be resolved with fewer rounds. And shorter matches mean players can play more, and more often. So with CS2, we\u2019re moving to a maximum of 24 rounds in regulation time (with a 6 round overtime in case of a tie) for Premier, Competitive, and the Majors.\n\nWe expect the structure and flow of matches to evolve over time as the community adapts. And we\u2019re excited to see where they go next.\n",
+            "feedlabel": "Community Announcements",
+            "date": 1693524157,
+            "feedname": "steam_community_announcements",
+            "feed_type": 1,
+            "appid": 730
         },
         {
-            'gid': 2,
-            'posterid': 2,
-            'headline': 'headline',
-            'posttime': 1679503830,
-            'updatetime': 2,
-            'body': 'body',
-            'event_type': 12
+            "gid": "5124585319846885283",
+            "title": "Release Notes for 8/2/2023",
+            "url": "https://steamstore-a.akamaihd.net/news/externalpost/steam_community_announcements/5124585319846885283",
+            "is_external_url": True,
+            "author": "jo",
+            "contents": "[ GAMEPLAY ]\n[list]\n[*] Disabled Wingman\n[/list]\n[ MAPS ]\n[list]\n[*] Added Anubis to Deathmatch, Casual, and Competitive game modes\n[*] Added Ancient to Deathmatch and Casual game modes\n[*] Removed Overpass and Vertigo\n[/list]\n[ MISC ]\n[list]\n[*] Taught chickens how to swim\n[*] Weapons splash when dropped in water\n[*] Adjusted grenade/water interaction sounds\n[/list]\n[ ANIMATION ]\n[list]\n[*] Improved head animation when crouching while running\n[*] Improved foot animation when quickly alternating between standing still and moving\n[/list]",
+            "feedlabel": "Community Announcements",
+            "date": 1691013634,
+            "feedname": "steam_community_announcements",
+            "feed_type": 1,
+            "appid": 730,
+            "tags": [
+                "patchnotes"
+            ]
         }
     ]

--- a/tests/test_post.py
+++ b/tests/test_post.py
@@ -2,75 +2,87 @@ from __future__ import annotations
 
 import pytest
 
-from cs2posts.post import EventType
+from cs2posts.post import FeedType
 from cs2posts.post import Post
 
 
 @pytest.fixture
 def post_fixture():
     return Post(gid="1",
-                posterid="2",
-                headline="Test",
-                posttime=1234567890,
-                updatetime=9876543210,
-                body="Test body",
-                event_type=12)
+                title="Test",
+                url="http://test.com",
+                is_external_url=True,
+                author="Test author",
+                contents="Test body",
+                date=1234567890,
+                feedlabel="Test label",
+                feedname="Test feed",
+                feed_type=1,
+                appid=730,
+                tags=["patchnotes"])
 
 
 @pytest.fixture
 def post_fixture2():
     return Post(gid="2",
-                posterid="2",
-                headline="Test2",
-                posttime=1234567890,
-                updatetime=9876543210,
-                body="Test body2",
-                event_type=13)
+                title="Test2",
+                url="http://test2.com",
+                is_external_url=True,
+                author="Test author2",
+                contents="Test body2",
+                date=1234567890,
+                feedlabel="Test label",
+                feedname="Test feed",
+                feed_type=1,
+                appid=730)
 
 
-def test_event_types():
-    assert EventType(12) == EventType.UPDATE
-    assert EventType(13) == EventType.NEWS
-    assert EventType(14) == EventType.SPECIAL
-    assert EventType(28) == EventType.EVENTS
-    assert EventType(-1) == EventType.NOT_DEFINED
-    assert EventType(0) == EventType.NOT_DEFINED
-    assert EventType(100) == EventType.NOT_DEFINED
+def test_feed_type():
+    assert FeedType(12) == FeedType.NOT_DEFINED
+    assert FeedType(-1) == FeedType.NOT_DEFINED
+    assert FeedType(0) == FeedType.EXTERN
+    assert FeedType(1) == FeedType.INTERN
 
 
 def test_post_is_update(post_fixture):
-    post_fixture.event_type = EventType.UPDATE.value
     assert post_fixture.is_update()
 
 
-def test_post_is_news(post_fixture):
-    post_fixture.event_type = EventType.NEWS.value
-    assert post_fixture.is_news()
-    post_fixture.event_type = EventType.SPECIAL.value
-    assert post_fixture.is_news()
-    post_fixture.event_type = EventType.EVENTS.value
-    assert post_fixture.is_news()
+def test_post_is_news(post_fixture2):
+    assert post_fixture2.is_news()
 
 
 def test_post_to_dict(post_fixture):
-    expected = {"gid": post_fixture.gid,
-                "posterid": post_fixture.posterid,
-                "headline": post_fixture.headline,
-                "posttime": post_fixture.posttime,
-                "updatetime": post_fixture.updatetime,
-                "body": post_fixture.body,
-                "event_type": post_fixture.event_type}
+    expected = {
+        "gid": post_fixture.gid,
+        "title": post_fixture.title,
+        "url": post_fixture.url,
+        "is_external_url": post_fixture.is_external_url,
+        "author": post_fixture.author,
+        "contents": post_fixture.contents,
+        "date": post_fixture.date,
+        "feedlabel": post_fixture.feedlabel,
+        "feedname": post_fixture.feedname,
+        "feed_type": post_fixture.feed_type,
+        "appid": post_fixture.appid,
+        "tags": post_fixture.tags
+    }
     assert post_fixture.to_dict() == expected
 
 
 def test_post_get_item(post_fixture):
     assert post_fixture["gid"] == post_fixture.gid
-    assert post_fixture["posterid"] == post_fixture.posterid
-    assert post_fixture["headline"] == post_fixture.headline
-    assert post_fixture["posttime"] == post_fixture.posttime
-    assert post_fixture["updatetime"] == post_fixture.updatetime
-    assert post_fixture["body"] == post_fixture.body
-    assert post_fixture["event_type"] == post_fixture.event_type
+    assert post_fixture["title"] == post_fixture.title
+    assert post_fixture["url"] == post_fixture.url
+    assert post_fixture["is_external_url"] == post_fixture.is_external_url
+    assert post_fixture["author"] == post_fixture.author
+    assert post_fixture["contents"] == post_fixture.contents
+    assert post_fixture["date"] == post_fixture.date
+    assert post_fixture["feedlabel"] == post_fixture.feedlabel
+    assert post_fixture["feedname"] == post_fixture.feedname
+    assert post_fixture["feed_type"] == post_fixture.feed_type
+    assert post_fixture["appid"] == post_fixture.appid
+    assert post_fixture["tags"] == post_fixture.tags
 
 
 def test_post_equals(post_fixture):
@@ -85,5 +97,5 @@ def test_post_not_equals(post_fixture, post_fixture2):
 def test_post_is_newer_than(post_fixture, post_fixture2):
     assert not post_fixture.is_newer_than(None)
     assert not post_fixture.is_newer_than(post_fixture2)
-    post_fixture2.posttime = 123456789
+    post_fixture2.date = 123456789
     assert post_fixture.is_newer_than(post_fixture2)

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -15,22 +15,34 @@ from cs2posts.store import Post
 def data_latest():
     return {
         "update": {
-            "gid": "12341122312",
-            "posterid": "76561199571358539",
-            "headline": "Release Notes for 1/4/2024",
-            "posttime": 1704407492,
-            "updatetime": 1704407760,
-            "body": "fixture_body_update",
-            "event_type": 12
+            "gid": "5762994032385146001",
+            "title": "Release Notes for 4/16/2024",
+            "url": "https://steamstore-a.akamaihd.net/news/externalpost/steam_community_announcements/5762994032385146001",
+            "is_external_url": True,
+            "author": "Vitaliy",
+            "contents": "[ MISC ]\n[list]\n[*] Fixed a bug where bomb can sometimes disappear from the radar\n[*] Allow scraping or removing stickers by selecting the sticker icons under the weapon\n[*] Allow deleting empty storage units that have an assigned label\n[*] Fixed Workshop tools from crashing when compiling maps that contain instances\n[/list]",
+            "feedlabel": "Community Announcements",
+            "date": 1713310428,
+            "feedname": "steam_community_announcements",
+            "feed_type": 1,
+            "appid": 730,
+            "tags": [
+                "patchnotes"
+            ]
         },
         "news": {
-            "gid": "1234567890",
-            "posterid": "76561197971400048",
-            "headline": "A Call to Arms",
-            "posttime": 1707265365,
-            "updatetime": 1707347147,
-            "body": "fixtre_body_news",
-            "event_type": 13
+            "gid": "5756237364302520223",
+            "title": "Copenhagen Major Champions",
+            "url": "https://steamstore-a.akamaihd.net/news/externalpost/steam_community_announcements/5756237364302520223",
+            "is_external_url": True,
+            "author": "Piggles ULTRAPRO",
+            "contents": "[img]https://clan.akamai.steamstatic.com/images/3381077/75c3204fcb2874385f7c3e1dafeb00003b76502e.png[/img]\nCongratulations to Natus Vincere, the first CS2 Major Champions!\n\nPlaying in front of a sold-out arena and with over 1.8 million viewers watching around the world, NAVI and FaZe met in the Grand Final of one of the most hotly-contested Counter-Strike Majors of all time. Trading map wins in Ancient and Mirage, the teams moved to Inferno for the decider. There, b1t, jL, Aleksib, iM, and w0nderful put on a dominating performance to earn the trophy and title of Major Champions.\n\nTo celebrate their achievement, the Copenhagen 2024 Major Champions Capsule is now available for purchase. The capsule features autographs for each member of the winning team in paper, glitter, holo, and gold. 50% of the proceeds go to the players and organizations.\n\nAnd with that, the Copenhagen Major has come to a close. See you next time in Shanghai!",
+            "feedlabel": "Community Announcements",
+            "date": 1712103491,
+            "feedname": "steam_community_announcements",
+            "feed_type": 1,
+            "appid": 730,
+            "tags": []
         }
     }
 
@@ -69,10 +81,10 @@ def test_local_latest_post_store_load(local_latest_post_store, data_latest):
 
 
 def test_local_latest_post_store_save(local_latest_post_store, data_latest):
-    expected_temp_update_title = data_latest["news"]["headline"]
+    expected_temp_update_title = data_latest["news"]["title"]
 
-    data_latest["update"]["headline"] = "New Update headline"
-    data_latest["news"]["headline"] = "New News headline"
+    data_latest["update"]["title"] = "New Update headline"
+    data_latest["news"]["title"] = "New News headline"
 
     actual_post_update = Post(**data_latest["update"])
     actual_post_news = Post(**data_latest["news"])
@@ -81,13 +93,13 @@ def test_local_latest_post_store_save(local_latest_post_store, data_latest):
     content = local_latest_post_store.load()
 
     # News headline should not be changed
-    assert content["news"]["headline"] == expected_temp_update_title
-    assert content["update"]["headline"] == "New Update headline"
+    assert content["news"]["title"] == expected_temp_update_title
+    assert content["update"]["title"] == "New Update headline"
 
     local_latest_post_store.save(actual_post_news)
 
     content = local_latest_post_store.load()
-    assert content["news"]["headline"] == "New News headline"
+    assert content["news"]["title"] == "New News headline"
 
 
 def test_local_latest_post_store_get_latest_news_post(local_latest_post_store, data_latest):


### PR DESCRIPTION
Instead of using the ajax event switch to official web api provided by valve.
This introduced some breaking changes in the `Post` object structure.

However we retrieve additional information, like

* author
* external posts on webpages
* non self made url links to post

External posts are currently not implemented to be posted.
Issue: #11 (blocked till sqllite is implemented)

* Additional option to enable external link posts
* Parser which can handle and parse these external content into a Telegram msg 

fixes #4 